### PR TITLE
Fix: make Windows exe use lowercase

### DIFF
--- a/src/claude_autoapprove_mcp/autoapprove_server.py
+++ b/src/claude_autoapprove_mcp/autoapprove_server.py
@@ -48,7 +48,7 @@ def get_main_claude_pid():
                 if proc.name() == "Claude" and "Claude.app" in str(proc.cmdline()):
                     claude_processes.append(proc)
             elif sys.platform == "win32":  # Windows
-                if "Claude.exe" in str(proc.name()) or "Claude.exe" in str(proc.cmdline()):
+                if "claude.exe" in str(proc.name()) or "claude.exe" in str(proc.cmdline()):
                     claude_processes.append(proc)
             else:
                 eprint(f"Unsupported platform: {sys.platform}")
@@ -117,7 +117,7 @@ def terminate_claude_process(pid):
     elif sys.platform == "win32":
         try:
             subprocess.run(
-                ["taskkill", "/IM", "Claude.exe"],
+                ["taskkill", "/IM", "claude.exe"],
                 check=False
             )
             time.sleep(1)


### PR DESCRIPTION
The MCP will fail and auto-disconnect on Claude for Windows.
```log
2025-04-23T18:37:36.437Z [info] [claude-autoapprove-mcp] Initializing server...
2025-04-23T18:37:36.450Z [info] [claude-autoapprove-mcp] Server started and connected successfully
2025-04-23T18:37:36.453Z [info] [claude-autoapprove-mcp] Message from client: {"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"claude-ai","version":"0.1.0"}},"jsonrpc":"2.0","id":0}
2025-04-23T18:37:46.179Z [info] [claude-autoapprove-mcp] Server transport closed
2025-04-23T18:37:46.179Z [info] [claude-autoapprove-mcp] Client transport closed
2025-04-23T18:37:46.180Z [info] [claude-autoapprove-mcp] Server transport closed unexpectedly, this is likely due to the process exiting early. If you are developing this MCP server you can add output to stderr (i.e. `console.error('...')` in JavaScript, `print('...', file=sys.stderr)` in python) and it will appear in this log.
2025-04-23T18:37:46.180Z [error] [claude-autoapprove-mcp] Server disconnected. For troubleshooting guidance, please visit our [debugging documentation](https://modelcontextprotocol.io/docs/tools/debugging)
2025-04-23T18:37:46.181Z [info] [claude-autoapprove-mcp] Client transport closed
```

Then I ran it via `uvx` cli:

```bash
~
❯ uvx claude-autoapprove-mcp
Claude Desktop is not listening on port 19222
Starting worker process to handle Claude restart...
Worker process started with PID: 34772
Exiting main process. Worker will handle Claude restart.
Restart worker started - will restart Claude with port: 19222
Identifying main Claude process...
No Claude process found to terminate
Starting Claude with debugging port 19222...
The system cannot find the file Claude.
Error starting Claude: Command '['start', '', 'Claude', '--remote-debugging-port=19222']' returned non-zero exit status 1.
```

Turns out the fix is as simple as replacing `Claude.exe` with `claude.exe` 😁